### PR TITLE
Move @SuppressWarnings("deprecation") to top of the class so you only have to write it once and not at every function

### DIFF
--- a/src/main/java/dev/turtywurty/fabrictechmodtesting/common/block/CableBlock.java
+++ b/src/main/java/dev/turtywurty/fabrictechmodtesting/common/block/CableBlock.java
@@ -42,6 +42,7 @@ import team.reborn.energy.api.EnergyStorage;
 
 import java.util.Locale;
 
+@SuppressWarnings("deprecation")
 public class CableBlock extends Block implements SimpleWaterloggedBlock, EntityBlock {
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
     public static final EnumProperty<ConnectorType> NORTH = EnumProperty.create("north", ConnectorType.class);
@@ -158,7 +159,6 @@ public class CableBlock extends Block implements SimpleWaterloggedBlock, EntityB
                 .setValue(DOWN, down);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState state, @NotNull BlockGetter blockGetter, @NotNull BlockPos pos, @NotNull CollisionContext context) {
         ConnectorType north = state.getValue(NORTH);
@@ -171,7 +171,6 @@ public class CableBlock extends Block implements SimpleWaterloggedBlock, EntityB
         return shapeCache[index];
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull BlockState updateShape(BlockState state, @NotNull Direction direction, @NotNull BlockState neighbourState, @NotNull LevelAccessor level, @NotNull BlockPos current, @NotNull BlockPos offset) {
         if (state.getValue(WATERLOGGED)) {
@@ -191,7 +190,6 @@ public class CableBlock extends Block implements SimpleWaterloggedBlock, EntityB
         return TickableBlockEntity.createTicker(level);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos fromPos, boolean isMoving) {
         super.neighborChanged(state, level, pos, block, fromPos, isMoving);
@@ -227,13 +225,11 @@ public class CableBlock extends Block implements SimpleWaterloggedBlock, EntityB
                 .setValue(WATERLOGGED, level.getFluidState(pos).getType() == Fluids.WATER));
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull FluidState getFluidState(BlockState state) {
         return state.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(state);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull InteractionResult use(BlockState blockState, Level level, BlockPos blockPos, Player player, InteractionHand interactionHand, BlockHitResult blockHitResult) {
         if (!level.isClientSide) {
@@ -246,7 +242,6 @@ public class CableBlock extends Block implements SimpleWaterloggedBlock, EntityB
         return InteractionResult.SUCCESS;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull RenderShape getRenderShape(BlockState blockState) {
         return RenderShape.INVISIBLE; // TODO: Remove this when the model is done

--- a/src/main/java/dev/turtywurty/fabrictechmodtesting/common/block/CrusherBlock.java
+++ b/src/main/java/dev/turtywurty/fabrictechmodtesting/common/block/CrusherBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings("deprecation")
 public class CrusherBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
     public static final BooleanProperty RUNNING = BooleanProperty.create("running");
@@ -33,7 +34,6 @@ public class CrusherBlock extends Block implements EntityBlock {
         registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(RUNNING, false));
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull InteractionResult use(BlockState blockState, Level level, BlockPos blockPos, Player player, InteractionHand interactionHand, BlockHitResult blockHitResult) {
         if (!level.isClientSide()) {
@@ -46,7 +46,6 @@ public class CrusherBlock extends Block implements EntityBlock {
         return InteractionResult.sidedSuccess(level.isClientSide());
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void onRemove(BlockState blockState, Level level, BlockPos blockPos, BlockState blockState2, boolean bl) {
         if (blockState.getBlock() != blockState2.getBlock()) {
@@ -60,13 +59,11 @@ public class CrusherBlock extends Block implements EntityBlock {
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public boolean hasAnalogOutputSignal(BlockState blockState) {
         return true;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public int getAnalogOutputSignal(BlockState blockState, Level level, BlockPos blockPos) {
         return AbstractContainerMenu.getRedstoneSignalFromBlockEntity(level.getBlockEntity(blockPos));

--- a/src/main/java/dev/turtywurty/fabrictechmodtesting/common/block/SolarPanelBlock.java
+++ b/src/main/java/dev/turtywurty/fabrictechmodtesting/common/block/SolarPanelBlock.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.EnumMap;
 import java.util.Map;
 
+@SuppressWarnings("deprecation")
 public class SolarPanelBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 
@@ -79,7 +80,6 @@ public class SolarPanelBlock extends Block implements EntityBlock {
         return shape.optimize();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull InteractionResult use(BlockState blockState, Level level, BlockPos blockPos, Player player, InteractionHand interactionHand, BlockHitResult blockHitResult) {
         if (!level.isClientSide) {
@@ -93,7 +93,6 @@ public class SolarPanelBlock extends Block implements EntityBlock {
         return InteractionResult.sidedSuccess(level.isClientSide);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void onRemove(BlockState blockState, Level level, BlockPos blockPos, BlockState blockState2, boolean bl) {
         if (blockState.getBlock() != blockState2.getBlock()) {
@@ -125,13 +124,11 @@ public class SolarPanelBlock extends Block implements EntityBlock {
         builder.add(FACING);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull BlockState rotate(BlockState blockState, Rotation rotation) {
         return blockState.setValue(FACING, rotation.rotate(blockState.getValue(FACING)));
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public @NotNull BlockState mirror(BlockState blockState, Mirror mirror) {
         return blockState.rotate(mirror.getRotation(blockState.getValue(FACING)));
@@ -143,19 +140,16 @@ public class SolarPanelBlock extends Block implements EntityBlock {
         return defaultBlockState().setValue(FACING, blockPlaceContext.getHorizontalDirection().getOpposite());
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public boolean hasAnalogOutputSignal(BlockState blockState) {
         return true;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public int getAnalogOutputSignal(BlockState blockState, Level level, BlockPos blockPos) {
         return level.getBlockEntity(blockPos) instanceof SolarPanelBlockEntity solarPanel ? solarPanel.getEnergyOutput() : 0;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public boolean isSignalSource(BlockState blockState) {
         return true;


### PR DESCRIPTION
You can move `@SuppressWarnings("deprecation")` onto the top level of the class so it suppresses all of the warnings